### PR TITLE
fix highlight at startup on gvim

### DIFF
--- a/plugin/sky_color_clock.vim
+++ b/plugin/sky_color_clock.vim
@@ -79,10 +79,5 @@ let g:sky_color_clock#openweathermap_api_key = get(g:, 'sky_color_clock#openweat
 let g:sky_color_clock#openweathermap_city_id = get(g:, 'sky_color_clock#openweathermap_city_id', '1850144')
 
 
-" for preload.
-call sky_color_clock#statusline()
-
-
-
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
何故かはよくわかりませんが、コミット 325b4dd 以降、gvimでの起動時のみ、最初にキャッシュが更新されるまでハイライトが為されない状態になっています。
起動時のみどこかでabortしているのでしょうか……。

とりあえず、preloadのコードを削除するだけで正常に動くようになったのでPRを送ります。
こちらでは不具合は見当たりませんでしたが、もし問題がありましたらご指摘ください。
