### PR TITLE
Use autocmd to preload, and reload on :colorscheme

### DIFF
--- a/autoload/sky_color_clock.vim
+++ b/autoload/sky_color_clock.vim
@@ -265,7 +265,7 @@ function! sky_color_clock#statusline() abort
 
     let statusline = strftime(g:sky_color_clock#datetime_format, now)
 
-    if statusline ==# strftime(g:sky_color_clock#datetime_format, s:last_update_timestamp) && !empty(s:statusline_cache)
+    if statusline ==# strftime(g:sky_color_clock#datetime_format, s:last_update_timestamp) && !empty(s:statusline_cache) && !empty(synIDattr(synIDtrans(hlID('SkyColorClock')), 'fg'))
         return s:statusline_cache
     endif
     let s:last_update_timestamp = now

--- a/plugin/sky_color_clock.vim
+++ b/plugin/sky_color_clock.vim
@@ -80,7 +80,9 @@ let g:sky_color_clock#openweathermap_city_id = get(g:, 'sky_color_clock#openweat
 
 
 " for preload.
-call sky_color_clock#statusline()
+augroup sky_color_clock
+    autocmd ColorScheme * call sky_color_clock#statusline()
+augroup END
 
 
 


### PR DESCRIPTION
一度プラグインがロードされた後に`:colorscheme`を実行したときにハイライトがクリアされてしまい、次に時計が更新されるタイミングまで時計の色がなくなってしまうのを改善しました。
具体的には、`autocmd ColorScheme`で、カラースキーム適用後に`sky_color_clock#statusline()`を呼ぶようにしています。

また、`sky_color_clock#statusline()`が呼ばれたときにハイライトグループ`SkyColorClock`がクリアされていたら、キャッシュの有無に関わらず更新するようにしています。

#2 もこのPRで改善すると思います。